### PR TITLE
Frontend/feature/modal new project

### DIFF
--- a/client/src/app/projects/ProjectHeader/ProjectHeader.tsx
+++ b/client/src/app/projects/ProjectHeader/ProjectHeader.tsx
@@ -1,5 +1,13 @@
 import { useState } from "react";
-import { Clock, Filter, Grid3x3, List, Share2, Table } from "lucide-react";
+import {
+  Clock,
+  Filter,
+  Grid3x3,
+  List,
+  PlusSquare,
+  Share2,
+  Table,
+} from "lucide-react";
 import Header from "@/components/Header/Header";
 
 type Props = {
@@ -12,10 +20,24 @@ const ProjectHeader = ({ activeTab, setActiveTab }: Props) => {
 
   return (
     <div className="px-4 xl:px-6">
-      {/* NODAL NEW PROJECT */}
-      <div className="py-6 lg:pt-8 lg:pb-4">
-        <Header name="Product Design Development" />
-      </div>
+      {/* MODAL NEW PROJECT */}
+      <ModalNewProject
+        isOpen={isModalNewProjectOpen}
+        onClose={() => setIsModalNewProjectOpen(false)}
+      />
+
+      {/* HEADER */}
+      <Header
+        name="Product Design Development"
+        buttonComponent={
+          <button
+            className="bg-blue-primary flex items-center rounded-md px-3 py-2 text-white hover:bg-blue-600"
+            onClick={() => setIsModalNewProjectOpen(true)}
+          >
+            <PlusSquare className="mr-2 h-5 w-5" /> New Boards
+          </button>
+        }
+      />
 
       {/* TABS */}
       <div className="dark:border-stroke-dark flex flex-wrap-reverse gap-2 border-y border-gray-200 pt-2 pb-[8px] md:items-center">

--- a/client/src/app/projects/ProjectHeader/ProjectHeader.tsx
+++ b/client/src/app/projects/ProjectHeader/ProjectHeader.tsx
@@ -9,6 +9,7 @@ import {
   Table,
 } from "lucide-react";
 import Header from "@/components/Header/Header";
+import ModalNewBoard from "@/components/ModalNewBoard/ModalNewBoard";
 
 type Props = {
   activeTab: string;
@@ -21,7 +22,7 @@ const ProjectHeader = ({ activeTab, setActiveTab }: Props) => {
   return (
     <div className="px-4 xl:px-6">
       {/* MODAL NEW PROJECT */}
-      <ModalNewProject
+      <ModalNewBoard
         isOpen={isModalNewProjectOpen}
         onClose={() => setIsModalNewProjectOpen(false)}
       />

--- a/client/src/components/Modal/Modal.tsx
+++ b/client/src/components/Modal/Modal.tsx
@@ -1,0 +1,38 @@
+import React from "react";
+import ReactDOM from "react-dom";
+import Header from "../Header/Header";
+import { X } from "lucide-react";
+
+type Props = {
+  children: React.ReactNode;
+  isOpen: boolean;
+  onClose: () => void;
+  name: string;
+};
+
+const Modal = ({ children, isOpen, onClose, name }: Props) => {
+  if (!isOpen) return null;
+
+  return ReactDOM.createPortal(
+    <div className="bg-opacity-50 fixed inset-0 z-50 flex h-full w-full items-center justify-center overflow-y-auto bg-gray-600 p-4">
+      <div className="dark:bg-dark-secondary w-full max-w-2xl rounded-lg bg-white p-4 shadow-lg">
+        <Header
+          name={name}
+          buttonComponent={
+            <button
+              className="bg-blue-primary flex h-7 w-7 items-center justify-center rounded-full text-white hover:bg-blue-600"
+              onClick={onClose}
+            >
+              <X size={18} />
+            </button>
+          }
+          isSmallText
+        />
+        {children}
+      </div>
+    </div>,
+    document.body,
+  );
+};
+
+export default Modal;

--- a/client/src/components/ModalNewBoard/ModalNewBoard.tsx
+++ b/client/src/components/ModalNewBoard/ModalNewBoard.tsx
@@ -1,0 +1,93 @@
+import Modal from "@/components/Modal/Modal";
+import { useCreateProjectMutation } from "@/store/api";
+import React, { useState } from "react";
+import { formatISO } from "date-fns";
+
+type Props = {
+  isOpen: boolean;
+  onClose: () => void;
+};
+
+const ModalNewBoard = ({ isOpen, onClose }: Props) => {
+  const [createProject, { isLoading }] = useCreateProjectMutation();
+  const [projectName, setProjectName] = useState("");
+  const [description, setDescription] = useState("");
+  const [startDate, setStartDate] = useState("");
+  const [endDate, setEndDate] = useState("");
+
+  const handleSubmit = async () => {
+    if (!projectName || !startDate || !endDate) return;
+
+    const formattedStartDate = formatISO(new Date(startDate), {
+      representation: "complete",
+    });
+    const formattedEndDate = formatISO(new Date(endDate), {
+      representation: "complete",
+    });
+
+    await createProject({
+      name: projectName,
+      description,
+      startDate: formattedStartDate,
+      endDate: formattedEndDate,
+    });
+  };
+
+  const isFormValid = () => {
+    return projectName && description && startDate && endDate;
+  };
+
+  const inputStyles =
+    "w-full rounded border border-gray-300 p-2 shadow-sm dark:border-dark-tertiary dark:bg-dark-tertiary dark:text-white dark:focus:outline-none";
+
+  return (
+    <Modal isOpen={isOpen} onClose={onClose} name="Create New Project">
+      <form
+        className="mt-4 space-y-6"
+        onSubmit={(e) => {
+          e.preventDefault();
+          handleSubmit();
+        }}
+      >
+        <input
+          type="text"
+          className={inputStyles}
+          placeholder="Project Name"
+          value={projectName}
+          onChange={(e) => setProjectName(e.target.value)}
+        />
+        <textarea
+          className={inputStyles}
+          placeholder="Description"
+          value={description}
+          onChange={(e) => setDescription(e.target.value)}
+        />
+        <div className="grid grid-cols-1 gap-6 sm:grid-cols-2 sm:gap-2">
+          <input
+            type="date"
+            className={inputStyles}
+            value={startDate}
+            onChange={(e) => setStartDate(e.target.value)}
+          />
+          <input
+            type="date"
+            className={inputStyles}
+            value={endDate}
+            onChange={(e) => setEndDate(e.target.value)}
+          />
+        </div>
+        <button
+          type="submit"
+          className={`focus-offset-2 bg-blue-primary mt-4 flex w-full justify-center rounded-md border border-transparent px-4 py-2 text-base font-medium text-white shadow-sm hover:bg-blue-600 focus:ring-2 focus:ring-blue-600 focus:outline-none ${
+            !isFormValid() || isLoading ? "cursor-not-allowed opacity-50" : ""
+          }`}
+          disabled={!isFormValid() || isLoading}
+        >
+          {isLoading ? "Creating..." : "Create Project"}
+        </button>
+      </form>
+    </Modal>
+  );
+};
+
+export default ModalNewBoard;


### PR DESCRIPTION
### Summary
This PR introduces a **New Boards** button to the Projects page header and sets up a reusable `Modal` component to handle board creation.

### Changes
- Added a **New Boards** button to the Projects page header.
- Implemented a reusable `Modal` component for consistent UI usage across the app.
- Created a `Modal` specifically for adding new boards.

### Motivation
These changes provide a cleaner and more user-friendly way to create new boards directly from the Projects page. The reusable `Modal` also reduces duplicate code and ensures consistent styling/behavior for future modal use cases.

### Testing
- Verified that clicking the **New Boards** button opens the `Modal`.
- Confirmed that the board creation modal behaves as expected (open/close flow).
- Checked UI consistency across light/dark themes.